### PR TITLE
Improve build for 0.7.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%PREFIX% .
+cmake -G "%CMAKE_GENERATOR%" -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%PREFIX% .
 cmake --build . --config release --target install
 
 :: Build and run the tests

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
-cmake -G "%CMAKE_GENERATOR%" -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%PREFIX% .
+cmake -G "%CMAKE_GENERATOR%" -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%PREFIX%/Library .
 cmake --build . --config release --target install
 
 :: Build and run the tests

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$PREFIX .
+cmake  -G "$CMAKE_GENERATOR" -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$PREFIX .
 cmake --build . --config release --target install
 
 # Build and run the tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   skip: true  # [win and py2k]
-  number: 0
+  number: 1
+  include_recipe: False
   features:
     - vc14  # [win]
 


### PR DESCRIPTION
This removes 23M of test files from the package, putting it size down to 660kB  from 24M on my machine, and make sure to build 64-bit DLL on 64-bit Windows.