### PR TITLE
Update to 0.8.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,3 @@
-if [[ "$(uname)" == "Linux" ]]; then
-    LDFLAGS="$LDFLAGS -static-libstdc++"
-fi
-
 cmake  -G "$CMAKE_GENERATOR" -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$PREFIX .
 cmake --build . --config release --target install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # Chemfiles version and SHA256
-{% set version = "0.8.0" %}
-{% set sha256 = "7a3b7b225e4439dc3026b25366d04f241e5510b6da415adaafcfa24f517794c7" %}
+{% set version = "0.8.1" %}
+{% set sha256 = "4c9afc289e1e703e90f8da109b46c1163348de1e013018f492daabef94612a8f" %}
 
 # Chemfiles test data git version and SHA256
 {% set data_git = "c26f254cd7bff7e476bf065403fbd0a6a47fea38" %}
@@ -22,7 +22,7 @@ source:
 
 build:
   skip: true  # [win and vc<14]
-  number: 2
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This should remove the need for static linking libstdc++ on Linux.